### PR TITLE
fix(2025): update the date

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,5 +1,5 @@
 {
-  "date": "2024-01",
+  "date": "2025-01",
   "entries": [
 
     { "quadrant": 0, "ring": 0, "label": "Github",  "active": true,  "moved": 0 },


### PR DESCRIPTION
This pull request includes a small change to the `docs/config.json` file. The change updates the `date` field to reflect the new year.

* [`docs/config.json`](diffhunk://#diff-6d9273c3bfa0b82e1f9b00029de2eff3cc18f3f06850bf3301b3586b60f463aaL2-R2): Updated the `date` field from "2024-01" to "2025-01".